### PR TITLE
Practical benchmarking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,8 +428,13 @@ impl ModSampling<RandomOrder> {
         let t = k - w;
         Self::new(k, w, t, RandomOrder)
     }
-    pub fn mod_minimizer(k: usize, w: usize) -> Self {
-        let r = 1;
+    pub fn mod_minimizer(k: usize, w: usize, sigma: usize) -> Self {
+        // Hack r based on performance of sigma=2, 4, and 256
+        let r = match sigma {
+            2 => 5,
+            4 => 3,
+            _ => 1,
+        };
         assert!(k > r);
         let t = (k - r) % w + r;
         Self::new(k, w, t, RandomOrder)


### PR DESCRIPTION
* Uses `r=5` for `sigma=2` and `r=3` for `sigma=1`. Otherwise, `r=1`.
* New `--practical` flag sets `k` range `6..64` and `w` range `[2, 5, 10, 19, 50]`
* New `--input FILE` argument uses the text in `FILE` as the benchmarking text. This should be mutually exclusive w/ `--small`, but is not enforced