### PR TITLE
Use crates.io for packed-seq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,16 +423,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.0-rc.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a78f88e84d239c7f2619ae8b091603c26208e1cb322571f5a29d6806f56ee5e"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "rustix",
  "wasi 0.13.3+wasi-0.2.2",
- "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -653,8 +650,8 @@ dependencies = [
  "num",
  "packed-seq",
  "pyo3",
- "rand",
- "rand_chacha 0.9.0-beta.1",
+ "rand 0.8.5",
+ "rand_chacha 0.9.0",
  "rayon",
  "serde",
  "serde_json",
@@ -797,12 +794,13 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "packed-seq"
-version = "0.1.0"
-source = "git+https://github.com/rust-seq/packed-seq#03126a76ce43fc9ddadacfded1eea35ce0632950"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66357293f640400f7aaa7bfc9551476f4cdb0577dc3a7b9b7371a33be8e23581"
 dependencies = [
  "cfg-if",
  "mem_dbg",
- "rand",
+ "rand 0.9.0",
  "wide",
 ]
 
@@ -948,6 +946,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.14",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,12 +968,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0-beta.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16da77124f4ee9fabd55ce6540866e9101431863b4876de58b68797f331adf2"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0-beta.1",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -978,12 +987,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0-beta.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98fa0b8309344136abe6244130311e76997e546f76fae8054422a7539b43df7"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.0-rc.0",
- "zerocopy 0.8.14",
+ "getrandom 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ color-backtrace = "0.6"
 pyo3 = { version = "0.22.2", features = ["extension-module"], optional = true }
 
 # 'Our own' deps.
-packed-seq = { version = "0.1.0", git = "https://github.com/rust-seq/packed-seq" }
+packed-seq = "1.0.0"
 # packed-seq = { version = "0.1.0", path = "../packed-seq" }
 typetag = "0.2.18"
 wide = "0.7.30"


### PR DESCRIPTION
Since packed-seq upgraded to 1.0.2 it does not match the  specified cargo version:

```
error: failed to select a version for the requirement `packed-seq = "^0.1.2"`
candidate versions found which didn't match: 1.0.2
location searched: Git repository https://github.com/rust-seq/packed-seq
required by package `minimizers v0.1.0 `
```

Perhaps just link  the crates.io now with the "old" version so it compiles.

(P.s. thanks for the lib!)
